### PR TITLE
Fix "reversed, reversed" in daily tarot

### DIFF
--- a/src/interpret.js
+++ b/src/interpret.js
@@ -13,9 +13,10 @@ function writeInterpretations() {
     `;
 
     document.getElementById('interpretations').innerHTML = CARDS.map((card, i) => {
+        const R = ", reversed"
         let cardName = card.name;
-        if (!card.upright) {
-            cardName += ", reversed"
+        if (!card.upright && !cardName.endsWith(R) ) {
+            cardName += R;
         }
         return `<li>
             <span class='interpCard'><b>${cardName}</b>: ${interp[cardCode(card)]}</span>


### PR DESCRIPTION
The `daily.json` is configured to have the 'reversed' suffix for nice display in other applications; this ensures that it isn't over-applied.